### PR TITLE
Delete duplicate error message

### DIFF
--- a/templates/app/runner/main.cc
+++ b/templates/app/runner/main.cc
@@ -36,7 +36,6 @@ int main(int argc, char** argv) {
   // The Flutter instance hosted by this window.
   FlutterWindow window(view_properties, project);
   if (!window.OnCreate()) {
-    std::cerr << "Failed to create a Flutter window." << std::endl;
     return 0;
   }
   window.Run();


### PR DESCRIPTION
I deleted the duplicate error message in main.cc.

```Shell
[ERROR][elinux_window_wayland.cc(668)] Failed to connect to the Wayland display.
[ERROR][elinux_window_wayland.cc(910)] Wayland display is invalid.
Failed to create view controller.
Failed to create a Flutter window.
```