### PR TITLE
Add all runtime mode to custom-devices

### DIFF
--- a/lib/elinux_device.dart
+++ b/lib/elinux_device.dart
@@ -80,6 +80,7 @@ class ELinuxDevice extends Device {
   final ELinuxLogReader _logReader = ELinuxLogReader();
 
   int _forwardedHostPort;
+  BuildMode _buildMode = BuildMode.debug;
 
   @override
   Future<bool> get isLocalEmulator async => false;
@@ -96,9 +97,10 @@ class ELinuxDevice extends Device {
   }
 
   @override
-  bool supportsRuntimeMode(BuildMode buildMode) => _desktop
-      ? buildMode != BuildMode.jitRelease
-      : buildMode == BuildMode.debug;
+  bool supportsRuntimeMode(BuildMode buildMode) {
+    _buildMode = buildMode;
+    return buildMode != BuildMode.jitRelease;
+  }
 
   @override
   Future<String> get sdkNameAndVersion async =>
@@ -124,7 +126,7 @@ class ELinuxDevice extends Device {
     }
 
     final String bundlePath =
-        app.outputDirectory(BuildMode.fromName('debug'), _targetArch);
+        app.outputDirectory(_buildMode, _targetArch);
     final bool result =
         await tryInstall(localPath: bundlePath, appName: app.name);
 

--- a/lib/elinux_device.dart
+++ b/lib/elinux_device.dart
@@ -125,8 +125,7 @@ class ELinuxDevice extends Device {
       return false;
     }
 
-    final String bundlePath =
-        app.outputDirectory(_buildMode, _targetArch);
+    final String bundlePath = app.outputDirectory(_buildMode, _targetArch);
     final bool result =
         await tryInstall(localPath: bundlePath, appName: app.name);
 


### PR DESCRIPTION
I added all runtime mode for custom-devices.

```Shell
$  flutter-elinux run -d raspberry-pi4 --debug
$  flutter-elinux run -d raspberry-pi4 --profile
$  flutter-elinux run -d raspberry-pi4 --release
```

## Related issues
- https://github.com/sony/flutter-elinux/issues/17#issuecomment-888924644