### PR TITLE
Fix device discovery issue

### DIFF
--- a/lib/elinux_device_discovery.dart
+++ b/lib/elinux_device_discovery.dart
@@ -165,7 +165,8 @@ class ELinuxDeviceDiscovery extends PollingDeviceDiscovery {
             throwOnError: true);
         stdout = result.stdout.trim();
       } on ProcessException catch (ex) {
-        throwToolExit('ping failed to list attached devices:\n$ex');
+        _logger.printError('ping failed to list attached devices:\n$ex');
+        continue;
       }
 
       if (result.exitCode == 0 &&


### PR DESCRIPTION
I fixed the following bug.

## Bug description
When we use custom-devices and some of them are not found, desktop devices isn't also listed.