### PR TITLE
Change default CMakeLists.txt

### DIFF
--- a/templates/app/CMakeLists.txt.tmpl
+++ b/templates/app/CMakeLists.txt.tmpl
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "{{projectName}}")

--- a/templates/app/CMakeLists.txt.tmpl
+++ b/templates/app/CMakeLists.txt.tmpl
@@ -3,7 +3,7 @@ project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "{{projectName}}")
 
-cmake_policy(SET CMP0079 NEW)
+cmake_policy(SET CMP0063 NEW)
 
 set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
 

--- a/templates/app/flutter/CMakeLists.txt
+++ b/templates/app/flutter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 
 set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
 

--- a/templates/app/flutter/CMakeLists.txt
+++ b/templates/app/flutter/CMakeLists.txt
@@ -59,16 +59,16 @@ list(APPEND CPP_WRAPPER_SOURCES_CORE
   "core_implementations.cc"
   "standard_codec.cc"
 )
-list(TRANSFORM CPP_WRAPPER_SOURCES_CORE PREPEND "${WRAPPER_ROOT}/")
+list_prepend(CPP_WRAPPER_SOURCES_CORE "${WRAPPER_ROOT}/")
 list(APPEND CPP_WRAPPER_SOURCES_PLUGIN
   "plugin_registrar.cc"
 )
-list(TRANSFORM CPP_WRAPPER_SOURCES_PLUGIN PREPEND "${WRAPPER_ROOT}/")
+list_prepend(CPP_WRAPPER_SOURCES_PLUGIN "${WRAPPER_ROOT}/")
 list(APPEND CPP_WRAPPER_SOURCES_APP
   "flutter_engine.cc"
   "flutter_view_controller.cc"
 )
-list(TRANSFORM CPP_WRAPPER_SOURCES_APP PREPEND "${WRAPPER_ROOT}/")
+list_prepend(CPP_WRAPPER_SOURCES_APP "${WRAPPER_ROOT}/")
 
 # Wrapper sources needed for a plugin.
 add_library(flutter_wrapper_plugin STATIC

--- a/templates/app/runner/CMakeLists.txt
+++ b/templates/app/runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 project(runner LANGUAGES CXX)
 
 if(FLUTTER_TARGET_BACKEND_TYPE MATCHES "gbm")


### PR DESCRIPTION
I changed default CMakeLists.txt to fix the following build error on Ubuntu 18.04 desktops.

```
Failed to cmake:
-- The CXX compiler identification is Clang 6.0.0
-- Check for working CXX compiler: /usr/bin/clang++
-- Check for working CXX compiler: /usr/bin/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring incomplete, errors occurred!
See also "/home/hidenori/workspace/sample/build/elinux/x64/release/CMakeFiles/CMakeOutput.log".

CMake Error at CMakeLists.txt:6 (cmake_policy):
  Policy "CMP0079" is not known to this version of CMake.

CMake Error at flutter/CMakeLists.txt:62 (list):
  list does not recognize sub-command TRANSFORM

CMake Error at flutter/CMakeLists.txt:66 (list):
  list does not recognize sub-command TRANSFORM

CMake Error at flutter/CMakeLists.txt:71 (list):
  list does not recognize sub-command TRANSFORM

CMake Error at CMakeLists.txt:78 (install):
  install TARGETS given target "sample" which does not exist in this
  directory.
```