### PR TITLE
Add target-compiler-triple option

### DIFF
--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -38,13 +38,20 @@ class BuildPackageCommand extends BuildSubCommand
       'target-arch',
       defaultsTo: _getCurrentHostPlatformArchName(),
       allowed: <String>['x64', 'arm64'],
-      help: 'Target architecture for which the the app is compiled',
+      help: 'Target architecture for which the app is compiled',
     );
     argParser.addOption(
       'target-backend-type',
       defaultsTo: 'wayland',
       allowed: <String>['wayland', 'gbm', 'eglstream', 'x11'],
       help: 'Target backend type that the app will run on devices.',
+    );
+    argParser.addOption(
+      'target-compiler-triple',
+      defaultsTo: 'aarch64-linux-gnu',
+      help: 'Target compiler triple for which the app is compiled. '
+          'This option is used only if the target architectures is '
+          'arm64 (for cross-building for x64 on arm64).',
     );
     argParser.addOption(
       'target-sysroot',
@@ -105,6 +112,7 @@ class BuildPackageCommand extends BuildSubCommand
     final ELinuxBuildInfo eLinuxBuildInfo = ELinuxBuildInfo(buildInfo,
         targetArch: targetArch,
         targetBackendType: stringArg('target-backend-type'),
+        targetCompilerTriple: stringArg('target-compiler-triple'),
         targetSysroot: stringArg('target-sysroot'),
         systemIncludeDirectories: stringArg('system-include-directories'));
     validateBuild(eLinuxBuildInfo);

--- a/lib/elinux_build_target.dart
+++ b/lib/elinux_build_target.dart
@@ -353,6 +353,7 @@ class NativeBundle {
     final String cmakeBuildType = buildMode.isPrecompiled ? 'Release' : 'Debug';
     final String targetArch = buildInfo.targetArch;
     final String hostArch = _getCurrentHostPlatformArchName();
+    final String targetCompilerTriple = buildInfo.targetCompilerTriple;
     final String targetSysroot = buildInfo.targetSysroot;
     final String systemIncludeDirectories = buildInfo.systemIncludeDirectories;
     final bool needCrossBuild = targetArch != hostArch;
@@ -365,10 +366,10 @@ class NativeBundle {
         if (needCrossBuild) '-DFLUTTER_TARGET_PLATFORM_SYSROOT=$targetSysroot',
         if (needCrossBuild && systemIncludeDirectories != null)
           '-DFLUTTER_SYSTEM_INCLUDE_DIRECTORIES=$systemIncludeDirectories',
-        if (needCrossBuildOptionsForArm64)
-          '-DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu',
-        if (needCrossBuildOptionsForArm64)
-          '-DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu',
+        if (needCrossBuildOptionsForArm64 && targetCompilerTriple != null)
+          '-DCMAKE_C_COMPILER_TARGET=$targetCompilerTriple',
+        if (needCrossBuildOptionsForArm64 && targetCompilerTriple != null)
+          '-DCMAKE_CXX_COMPILER_TARGET=$targetCompilerTriple',
         eLinuxDir.path,
       ],
       workingDirectory: outputDir.path,

--- a/lib/elinux_builder.dart
+++ b/lib/elinux_builder.dart
@@ -35,6 +35,7 @@ class ELinuxBuildInfo {
     this.buildInfo, {
     @required this.targetArch,
     @required this.targetBackendType,
+    @required this.targetCompilerTriple,
     @required this.targetSysroot,
     @required this.systemIncludeDirectories,
   })  : assert(targetArch != null),
@@ -43,6 +44,7 @@ class ELinuxBuildInfo {
   final BuildInfo buildInfo;
   final String targetArch;
   final String targetBackendType;
+  final String targetCompilerTriple;
   final String targetSysroot;
   final String systemIncludeDirectories;
 }

--- a/lib/elinux_device.dart
+++ b/lib/elinux_device.dart
@@ -291,12 +291,13 @@ class ELinuxDevice extends Device {
     BuildInfo buildInfo,
   }) async {
     final FlutterProject project = FlutterProject.current();
-    // TODO(hidenori): change the fixed values (|targetSysroot| and |systemIncludeDirectories|)
+    // TODO(hidenori): change the fixed values (|targetSysroot|, |systemIncludeDirectories| and |targetCompilerTriple|)
     //  to the values from user-specified custom-devices feilds.
     final ELinuxBuildInfo eLinuxBuildInfo = ELinuxBuildInfo(
       buildInfo,
       targetArch: _targetArch,
       targetBackendType: _backendType,
+      targetCompilerTriple: null,
       targetSysroot: '/',
       systemIncludeDirectories: null,
     );


### PR DESCRIPTION
Added `target-compiler-triple` option for cross-building.

https://github.com/sony/flutter-elinux/issues/48