### PR TITLE
Change how sysroot is passed to CMake.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 
 Sony Group Corporation
 Michael Lamers (info@devmil.de)
+Andrea Daoud (andreadaoud6@gmail.com)

--- a/lib/elinux_build_target.dart
+++ b/lib/elinux_build_target.dart
@@ -351,7 +351,8 @@ class NativeBundle {
 
     // Run the native build.
     final String cmakeBuildType = buildMode.isPrecompiled ? 'Release' : 'Debug';
-    final String targetArch = buildInfo.targetArch == 'arm64' ? 'aarch64' : 'x86_64';
+    final String targetArch =
+        buildInfo.targetArch == 'arm64' ? 'aarch64' : 'x86_64';
     final String hostArch = _getCurrentHostPlatformArchName();
     final String targetCompilerTriple = buildInfo.targetCompilerTriple;
     final String targetSysroot = buildInfo.targetSysroot;
@@ -362,7 +363,8 @@ class NativeBundle {
         '-DCMAKE_BUILD_TYPE=$cmakeBuildType',
         '-DFLUTTER_TARGET_BACKEND_TYPE=${buildInfo.targetBackendType}',
         if (targetSysroot != '/') '-DCMAKE_SYSROOT=$targetSysroot',
-        if (buildInfo.targetArch != hostArch) '-DCMAKE_SYSTEM_PROCESSOR=$targetArch',
+        if (buildInfo.targetArch != hostArch)
+          '-DCMAKE_SYSTEM_PROCESSOR=$targetArch',
         if (systemIncludeDirectories != null)
           '-DFLUTTER_SYSTEM_INCLUDE_DIRECTORIES=$systemIncludeDirectories',
         if (targetCompilerTriple != null)

--- a/lib/elinux_build_target.dart
+++ b/lib/elinux_build_target.dart
@@ -354,7 +354,6 @@ class NativeBundle {
     final String targetArch = buildInfo.targetArch == 'arm64' ? 'aarch64' : 'x86_64';
     final String hostArch = _getCurrentHostPlatformArchName();
     final String targetCompilerTriple = buildInfo.targetCompilerTriple;
-    final String targetCompilerFlags = buildInfo.targetCompilerFlags;
     final String targetSysroot = buildInfo.targetSysroot;
     final String systemIncludeDirectories = buildInfo.systemIncludeDirectories;
     RunResult result = await _processUtils.run(

--- a/lib/elinux_build_target.dart
+++ b/lib/elinux_build_target.dart
@@ -352,22 +352,23 @@ class NativeBundle {
     // Run the native build.
     final String cmakeBuildType = buildMode.isPrecompiled ? 'Release' : 'Debug';
     final String targetArch = buildInfo.targetArch == 'arm64' ? 'aarch64' : 'x86_64';
+    final String hostArch = _getCurrentHostPlatformArchName();
     final String targetCompilerTriple = buildInfo.targetCompilerTriple;
+    final String targetCompilerFlags = buildInfo.targetCompilerFlags;
     final String targetSysroot = buildInfo.targetSysroot;
     final String systemIncludeDirectories = buildInfo.systemIncludeDirectories;
-    final bool needCrossBuild = targetSysroot != '/';
     RunResult result = await _processUtils.run(
       <String>[
         'cmake',
         '-DCMAKE_BUILD_TYPE=$cmakeBuildType',
         '-DFLUTTER_TARGET_BACKEND_TYPE=${buildInfo.targetBackendType}',
-        if (needCrossBuild) '-DCMAKE_SYSROOT=$targetSysroot',
-        if (needCrossBuild) '-DCMAKE_SYSTEM_PROCESSOR=$targetArch',
-        if (needCrossBuild && systemIncludeDirectories != null)
+        if (targetSysroot != '/') '-DCMAKE_SYSROOT=$targetSysroot',
+        if (buildInfo.targetArch != hostArch) '-DCMAKE_SYSTEM_PROCESSOR=$targetArch',
+        if (systemIncludeDirectories != null)
           '-DFLUTTER_SYSTEM_INCLUDE_DIRECTORIES=$systemIncludeDirectories',
-        if (needCrossBuild && targetCompilerTriple != null)
+        if (targetCompilerTriple != null)
           '-DCMAKE_C_COMPILER_TARGET=$targetCompilerTriple',
-        if (needCrossBuild && targetCompilerTriple != null)
+        if (targetCompilerTriple != null)
           '-DCMAKE_CXX_COMPILER_TARGET=$targetCompilerTriple',
         eLinuxDir.path,
       ],

--- a/lib/elinux_build_target.dart
+++ b/lib/elinux_build_target.dart
@@ -351,24 +351,23 @@ class NativeBundle {
 
     // Run the native build.
     final String cmakeBuildType = buildMode.isPrecompiled ? 'Release' : 'Debug';
-    final String targetArch = buildInfo.targetArch;
-    final String hostArch = _getCurrentHostPlatformArchName();
+    final String targetArch = buildInfo.targetArch == 'arm64' ? 'aarch64' : 'x86_64';
     final String targetCompilerTriple = buildInfo.targetCompilerTriple;
     final String targetSysroot = buildInfo.targetSysroot;
     final String systemIncludeDirectories = buildInfo.systemIncludeDirectories;
-    final bool needCrossBuild = targetArch != hostArch;
-    final bool needCrossBuildOptionsForArm64 = targetArch == 'arm64';
+    final bool needCrossBuild = targetSysroot != '/';
     RunResult result = await _processUtils.run(
       <String>[
         'cmake',
         '-DCMAKE_BUILD_TYPE=$cmakeBuildType',
         '-DFLUTTER_TARGET_BACKEND_TYPE=${buildInfo.targetBackendType}',
-        if (needCrossBuild) '-DFLUTTER_TARGET_PLATFORM_SYSROOT=$targetSysroot',
+        if (needCrossBuild) '-DCMAKE_SYSROOT=$targetSysroot',
+        if (needCrossBuild) '-DCMAKE_SYSTEM_PROCESSOR=$targetArch',
         if (needCrossBuild && systemIncludeDirectories != null)
           '-DFLUTTER_SYSTEM_INCLUDE_DIRECTORIES=$systemIncludeDirectories',
-        if (needCrossBuildOptionsForArm64 && targetCompilerTriple != null)
+        if (needCrossBuild && targetCompilerTriple != null)
           '-DCMAKE_C_COMPILER_TARGET=$targetCompilerTriple',
-        if (needCrossBuildOptionsForArm64 && targetCompilerTriple != null)
+        if (needCrossBuild && targetCompilerTriple != null)
           '-DCMAKE_CXX_COMPILER_TARGET=$targetCompilerTriple',
         eLinuxDir.path,
       ],

--- a/templates/app/CMakeLists.txt.tmpl
+++ b/templates/app/CMakeLists.txt.tmpl
@@ -7,21 +7,13 @@ cmake_policy(SET CMP0063 NEW)
 
 set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
 
-# Root filesystem for cross-building.
-if(FLUTTER_TARGET_PLATFORM_SYSROOT)
-  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
-  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
-  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
-  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-
-  # Basically we use this include when we got the following error:
-  #  fatal error: 'bits/c++config.h' file not found
-  if(FLUTTER_TARGET_PLATFORM_SYSROOT)
-    include_directories(SYSTEM ${FLUTTER_SYSTEM_INCLUDE_DIRECTORIES})
-  endif()
-endif()
+# Basically we use this include when we got the following error:
+#  fatal error: 'bits/c++config.h' file not found
+include_directories(SYSTEM ${FLUTTER_SYSTEM_INCLUDE_DIRECTORIES})
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
 # Configure build options.
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
In the CMake documentation, it is specified that the CMAKE_SYSROOT variable should be passed in toolchain file variable. It has no effect to set this variable in CMakeLists.txt like the current implementation. (This is why CMAKE_FIND_ROOT_PATH is needed.) The --sysroot option is not passed to the compiler in the current approach.

This commit, instead, sets the sysroot variable in CMake command line arguments. This makes it effective, and no CMAKE_FIND_ROOT_PATH is needed.

Moreover, it is not the duty of architecture to decide whether we are cross-compiling or not. For example, if I compile this on my Linux VM on mac M1 to i.MX8 processor, both host and target has the same arm64 architecture, but they doesn't share the same sysroot, so the standard cross-compile procedure should be followed. So, the real difference for cross-compile is that whether we share the same sysroot, rather than whether we have the same arch. This commit changes the detection method to compare sysroot.

Please test this, thanks!