### PR TITLE
Add --target-compiler-flags argument to specify flags for clang

### DIFF
--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -68,6 +68,11 @@ class BuildPackageCommand extends BuildSubCommand
           'This option is valid only '
           'if the current host and target architectures are different.',
     );
+    argParser.addOption(
+      'target-compiler-flags',
+      defaultsTo: null,
+      help: 'The extra compile flags to be applied to C and C++ compiler',
+    );
   }
 
   @override
@@ -109,12 +114,15 @@ class BuildPackageCommand extends BuildSubCommand
     }
 
     final BuildInfo buildInfo = await getBuildInfo();
-    final ELinuxBuildInfo eLinuxBuildInfo = ELinuxBuildInfo(buildInfo,
-        targetArch: targetArch,
-        targetBackendType: stringArg('target-backend-type'),
-        targetCompilerTriple: stringArg('target-compiler-triple'),
-        targetSysroot: stringArg('target-sysroot'),
-        systemIncludeDirectories: stringArg('system-include-directories'));
+    final ELinuxBuildInfo eLinuxBuildInfo = ELinuxBuildInfo(
+      buildInfo,
+      targetArch: targetArch,
+      targetBackendType: stringArg('target-backend-type'),
+      targetCompilerTriple: stringArg('target-compiler-triple'),
+      targetSysroot: stringArg('target-sysroot'),
+      systemIncludeDirectories: stringArg('system-include-directories'),
+      targetCompilerFlags: stringArg('target-compiler-flags'),
+    );
     validateBuild(eLinuxBuildInfo);
     displayNullSafetyMode(buildInfo);
 

--- a/lib/elinux_build_target.dart
+++ b/lib/elinux_build_target.dart
@@ -356,6 +356,7 @@ class NativeBundle {
     final String hostArch = _getCurrentHostPlatformArchName();
     final String targetCompilerTriple = buildInfo.targetCompilerTriple;
     final String targetSysroot = buildInfo.targetSysroot;
+    final String targetCompilerFlags = buildInfo.targetCompilerFlags;
     final String systemIncludeDirectories = buildInfo.systemIncludeDirectories;
     RunResult result = await _processUtils.run(
       <String>[
@@ -371,10 +372,14 @@ class NativeBundle {
           '-DCMAKE_C_COMPILER_TARGET=$targetCompilerTriple',
         if (targetCompilerTriple != null)
           '-DCMAKE_CXX_COMPILER_TARGET=$targetCompilerTriple',
+        if (targetCompilerFlags != null) '-DCMAKE_C_FLAGS=$targetCompilerFlags',
+        if (targetCompilerFlags != null)
+          '-DCMAKE_CXX_FLAGS=$targetCompilerFlags',
+        '-DCMAKE_C_COMPILER=clang',
+        '-DCMAKE_CXX_COMPILER=clang++',
         eLinuxDir.path,
       ],
       workingDirectory: outputDir.path,
-      environment: <String, String>{'CC': 'clang', 'CXX': 'clang++'},
     );
     if (result.exitCode != 0) {
       throwToolExit('Failed to cmake:\n$result');

--- a/lib/elinux_builder.dart
+++ b/lib/elinux_builder.dart
@@ -38,6 +38,7 @@ class ELinuxBuildInfo {
     @required this.targetCompilerTriple,
     @required this.targetSysroot,
     @required this.systemIncludeDirectories,
+    @required this.targetCompilerFlags,
   })  : assert(targetArch != null),
         assert(targetBackendType != null);
 
@@ -47,6 +48,7 @@ class ELinuxBuildInfo {
   final String targetCompilerTriple;
   final String targetSysroot;
   final String systemIncludeDirectories;
+  final String targetCompilerFlags;
 }
 
 /// See:

--- a/lib/elinux_device.dart
+++ b/lib/elinux_device.dart
@@ -300,6 +300,7 @@ class ELinuxDevice extends Device {
       targetCompilerTriple: null,
       targetSysroot: '/',
       systemIncludeDirectories: null,
+      targetCompilerFlags: null,
     );
     await ELinuxBuilder.buildBundle(
       project: project,


### PR DESCRIPTION
Close #104.

Add `--target-compiler-flags` argument to specify flags for clang

Also, avoid using environment variables to prevent interference to other commands run by CMake. Only CMAKE_C(XX)_COMPILER is sufficient to build flutter.

This flag is used to specify `--gcc-toolchain` option to clang. Without this option, clang won't be able to find correct gcc libraries on Buildroot environment.

Please add this to Wiki https://github.com/sony/flutter-elinux/wiki/Building-flutter-apps if appropiate:

### Case 3: Use Buildroot Toolchain
As Buildroot doesn't come with clang tool, you should install it yourself. In the command below, clang will use `aarch64-buildroot-linux-gnu-ld`, which comes with your buildroot, as the linker.

```
sudo apt install clang
sudo apt install wayland-protocols libwayland-bin # host tools needed to build wayland backend

export PATH=$PATH:~/buildroot/output/host/bin # add aarch64-buildroot-linux-gnu-ld to PATH

~/flutter-elinux/bin/flutter-elinux build elinux --target-arch=arm64 \
                                                 --target-compiler-triple=aarch64-buildroot-linux-gnu \
                                                 --target-sysroot=~/buildroot/output/staging \
                                                 --target-compiler-flags=--gcc-toolchain=~/buildroot/output/host
```
