### PR TITLE
Fix build command

### DIFF
--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -48,10 +48,9 @@ class BuildPackageCommand extends BuildSubCommand
     );
     argParser.addOption(
       'target-compiler-triple',
-      defaultsTo: 'aarch64-linux-gnu',
+      defaultsTo: null,
       help: 'Target compiler triple for which the app is compiled. '
-          'This option is used only if the target architectures is '
-          'arm64 (for cross-building for x64 on arm64).',
+          'e.g. aarch64-linux-gnu',
     );
     argParser.addOption(
       'target-sysroot',


### PR DESCRIPTION
Currently, When building flutter apps on x64, the default value of 'target-compiler-triple' has been set to 'aarch64-linux-gnu'.

```
Flutter 3.0.5 • channel unknown • unknown source
Framework • revision f1875d570e (4 weeks ago) • 2022-07-13 11:24:16 -0700
Engine • revision e85ea0e79c
Tools • Dart 2.17.6 • DevTools 2.12.2
[  +65 ms] executing: uname -m
[  +31 ms] Exit code 0 from: uname -m
[        ] x86_64
[  +10 ms] executing: [/home/hidenori/workspace/flutter/flutter-elinux/flutter/] git -c log.showSignature=false log -n 1 --pretty=format:%H
[   +7 ms] Exit code 0 from: git -c log.showSignature=false log -n 1 --pretty=format:%H
[        ] f1875d570e39de09040c8f79aa13cc56baab8db1
[        ] executing: [/home/hidenori/workspace/flutter/flutter-elinux/flutter/] git tag --points-at f1875d570e39de09040c8f79aa13cc56baab8db1
[  +19 ms] Exit code 0 from: git tag --points-at f1875d570e39de09040c8f79aa13cc56baab8db1
[        ] 3.0.5
[  +35 ms] executing: [/home/hidenori/workspace/flutter/flutter-elinux/flutter/] git rev-parse --abbrev-ref HEAD
[   +7 ms] Exit code 0 from: git rev-parse --abbrev-ref HEAD
[        ] HEAD
[        ] executing: [/home/hidenori/workspace/flutter/flutter-elinux/flutter/] git rev-parse --abbrev-ref --symbolic @{u}
[   +7 ms] Exit code 128 from: git rev-parse --abbrev-ref --symbolic @{u}
[        ] fatal: HEAD does not point to a branch
[  +24 ms] Unable to locate an Android SDK.
[ +222 ms] Artifact Instance of 'AndroidGenSnapshotArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterWebSdk' is not required, skipping update.
[   +2 ms] Artifact Instance of 'WindowsEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'WindowsUwpEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
[  +17 ms] Artifact Instance of 'ELinuxEngineArtifacts' is not required, skipping update.
[   +1 ms] Artifact Instance of 'MaterialFonts' is not required, skipping update.
[        ] Artifact Instance of 'GradleWrapper' is not required, skipping update.
[   +2 ms] Artifact Instance of 'AndroidInternalBuildArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterWebSdk' is not required, skipping update.
[        ] Artifact Instance of 'FlutterSdk' is not required, skipping update.
[        ] Artifact Instance of 'WindowsEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'WindowsUwpEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxEngineArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'LinuxFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'MacOSFuchsiaSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerSDKArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FlutterRunnerDebugSymbols' is not required, skipping update.
[        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'IosUsbArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'FontSubsetArtifacts' is not required, skipping update.
[        ] Artifact Instance of 'PubDependencies' is not required, skipping update.
[  +12 ms] Skipping pub get: version match.
[  +77 ms] Generating /home/hidenori/workspace/flutter/sample/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
[  +28 ms] 💪 Building with sound null safety 💪
[   +4 ms] Building an eLinux application with wayland backend in release mode for x64 target...
[   +2 ms] Initializing file store
[  +15 ms] Skipping target: gen_localizations
[  +11 ms] gen_dart_plugin_registrant: Starting due to {InvalidatedReasonKind.inputChanged: The following inputs have updated contents: /home/hidenori/workspace/flutter/sample/.dart_tool/package_config_subset}
[   +2 ms] elinux_plugins: Starting due to {}
[   +3 ms] elinux_plugins: Complete
[  +16 ms] gen_dart_plugin_registrant: Complete
[        ] kernel_snapshot: Starting due to {}
[  +10 ms] /home/hidenori/workspace/flutter/flutter-elinux/flutter/bin/cache/dart-sdk/bin/dart --disable-dart-dev /home/hidenori/workspace/flutter/flutter-elinux/flutter/bin/cache/dart-sdk/bin/snapshots/frontend_server.dart.snapshot --sdk-root /home/hidenori/workspace/flutter/flutter-elinux/flutter/bin/cache/artifacts/engine/common/flutter_patched_sdk_product/ --target=flutter --no-print-incremental-dependencies -Ddart.vm.profile=false -Ddart.vm.product=true --aot --tfa --packages /home/hidenori/workspace/flutter/sample/.dart_tool/package_config.json --output-dill /home/hidenori/workspace/flutter/sample/.dart_tool/flutter_build/114d17e923945509b2e7b801b30ea359/app.dill --depfile /home/hidenori/workspace/flutter/sample/.dart_tool/flutter_build/114d17e923945509b2e7b801b30ea359/kernel_snapshot.d package:sample/main.dart
[+11421 ms] kernel_snapshot: Complete
[ +343 ms] elinux_aot_elf: Starting due to {InvalidatedReasonKind.inputChanged: The following inputs have updated contents: /home/hidenori/workspace/flutter/sample/.dart_tool/flutter_build/114d17e923945509b2e7b801b30ea359/app.dill,/home/hidenori/workspace/flutter/flutter-elinux/flutter/bin/internal/engine.version,/home/hidenori/workspace/flutter/flutter-elinux/flutter/bin/internal/engine.version,/home/hidenori/workspace/flutter/flutter-elinux/flutter/bin/internal/engine.version}
[   +6 ms] executing: /home/hidenori/workspace/flutter/flutter-elinux/flutter/bin/cache/artifacts/engine/elinux-x64-release/linux-x64/gen_snapshot --deterministic --snapshot_kind=app-aot-elf --elf=/home/hidenori/workspace/flutter/sample/.dart_tool/flutter_build/114d17e923945509b2e7b801b30ea359/app.so --strip /home/hidenori/workspace/flutter/sample/.dart_tool/flutter_build/114d17e923945509b2e7b801b30ea359/app.dill
[+4254 ms] elinux_aot_elf: Complete
[  +22 ms] release_elinux_application: Starting due to {}
[  +95 ms] Running command: /home/hidenori/workspace/flutter/flutter-elinux/flutter/bin/cache/dart-sdk/bin/dart --disable-dart-dev /home/hidenori/workspace/flutter/flutter-elinux/flutter/bin/cache/artifacts/engine/linux-x64/const_finder.dart.snapshot --kernel-file /home/hidenori/workspace/flutter/sample/.dart_tool/flutter_build/114d17e923945509b2e7b801b30ea359/app.dill --class-library-uri package:flutter/src/widgets/icon_data.dart --class-name IconData
[ +652 ms] Running font-subset: /home/hidenori/workspace/flutter/flutter-elinux/flutter/bin/cache/artifacts/engine/linux-x64/font-subset /home/hidenori/workspace/flutter/sample/build/elinux/flutter_assets/fonts/MaterialIcons-Regular.otf /home/hidenori/workspace/flutter/flutter-elinux/flutter/bin/cache/artifacts/material_fonts/MaterialIcons-Regular.otf, using codepoints 58727 58332 57490 57491 57706 57415
[  +12 ms] release_elinux_application: Complete
[ +187 ms] Persisting file store
[   +5 ms] Done persisting file store
[  +72 ms] executing: [/home/hidenori/workspace/flutter/sample/build/elinux/x64/release/] cmake -DCMAKE_BUILD_TYPE=Release -DFLUTTER_TARGET_BACKEND_TYPE=wayland -DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu /home/hidenori/workspace/flutter/sample/elinux
[ +195 ms] -- The CXX compiler identification is Clang 14.0.0
           -- Detecting CXX compiler ABI info
           -- Detecting CXX compiler ABI info - done
           -- Check for working CXX compiler: //bin/clang++ - skipped
           -- Detecting CXX compile features
           -- Detecting CXX compile features - done
           -- Configuring done
           -- Generating done
           -- Build files have been written to: /home/hidenori/workspace/flutter/sample/build/elinux/x64/release
[        ] executing: [/home/hidenori/workspace/flutter/sample/build/elinux/x64/release/] cmake --build .
[+10043 ms] [  0%] Built target flutter_assemble
            [  7%] Building CXX object flutter/CMakeFiles/flutter_wrapper_plugin.dir/ephemeral/cpp_client_wrapper/core_implementations.cc.o
            [ 15%] Building CXX object flutter/CMakeFiles/flutter_wrapper_plugin.dir/ephemeral/cpp_client_wrapper/standard_codec.cc.o
            [ 23%] Building CXX object flutter/CMakeFiles/flutter_wrapper_plugin.dir/ephemeral/cpp_client_wrapper/plugin_registrar.cc.o
            [ 30%] Linking CXX static library libflutter_wrapper_plugin.a
            [ 30%] Built target flutter_wrapper_plugin
            [ 38%] Building CXX object flutter/CMakeFiles/flutter_wrapper_app.dir/ephemeral/cpp_client_wrapper/core_implementations.cc.o
            [ 46%] Building CXX object flutter/CMakeFiles/flutter_wrapper_app.dir/ephemeral/cpp_client_wrapper/standard_codec.cc.o
            [ 53%] Building CXX object flutter/CMakeFiles/flutter_wrapper_app.dir/ephemeral/cpp_client_wrapper/flutter_engine.cc.o
            [ 61%] Building CXX object flutter/CMakeFiles/flutter_wrapper_app.dir/ephemeral/cpp_client_wrapper/flutter_view_controller.cc.o
            [ 69%] Linking CXX static library libflutter_wrapper_app.a
            [ 69%] Built target flutter_wrapper_app
            [ 76%] Building CXX object runner/CMakeFiles/sample.dir/flutter_window.cc.o
            [ 84%] Building CXX object runner/CMakeFiles/sample.dir/main.cc.o
            [ 92%] Building CXX object runner/CMakeFiles/sample.dir/__/flutter/generated_plugin_registrant.cc.o
            [100%] Linking CXX executable sample

            //bin/aarch64-linux-gnu-ld: /home/hidenori/workspace/flutter/sample/elinux/flutter/ephemeral/libflutter_engine.so: error adding symbols: file in wrong format
            clang: error: linker command failed with exit code 1 (use -v to see invocation)
            gmake[2]: *** [runner/CMakeFiles/sample.dir/build.make:132: runner/sample] エラー 1
            gmake[1]: *** [CMakeFiles/Makefile2:198: runner/CMakeFiles/sample.dir/all] エラー 2
            gmake: *** [Makefile:136: all] エラー 2
[  +10 ms] Building an eLinux application with wayland backend in release mode for x64 target... (completed in 27.4s)
[   +1 ms] "flutter elinux" took 27,740ms.
[   +3 ms] Failed to cmake build:
           [  0%] Built target flutter_assemble
           [  7%] Building CXX object flutter/CMakeFiles/flutter_wrapper_plugin.dir/ephemeral/cpp_client_wrapper/core_implementations.cc.o
           [ 15%] Building CXX object flutter/CMakeFiles/flutter_wrapper_plugin.dir/ephemeral/cpp_client_wrapper/standard_codec.cc.o
           [ 23%] Building CXX object flutter/CMakeFiles/flutter_wrapper_plugin.dir/ephemeral/cpp_client_wrapper/plugin_registrar.cc.o
           [ 30%] Linking CXX static library libflutter_wrapper_plugin.a
           [ 30%] Built target flutter_wrapper_plugin
           [ 38%] Building CXX object flutter/CMakeFiles/flutter_wrapper_app.dir/ephemeral/cpp_client_wrapper/core_implementations.cc.o
           [ 46%] Building CXX object flutter/CMakeFiles/flutter_wrapper_app.dir/ephemeral/cpp_client_wrapper/standard_codec.cc.o
           [ 53%] Building CXX object flutter/CMakeFiles/flutter_wrapper_app.dir/ephemeral/cpp_client_wrapper/flutter_engine.cc.o
           [ 61%] Building CXX object flutter/CMakeFiles/flutter_wrapper_app.dir/ephemeral/cpp_client_wrapper/flutter_view_controller.cc.o
           [ 69%] Linking CXX static library libflutter_wrapper_app.a
           [ 69%] Built target flutter_wrapper_app
           [ 76%] Building CXX object runner/CMakeFiles/sample.dir/flutter_window.cc.o
           [ 84%] Building CXX object runner/CMakeFiles/sample.dir/main.cc.o
           [ 92%] Building CXX object runner/CMakeFiles/sample.dir/__/flutter/generated_plugin_registrant.cc.o
           [100%] Linking CXX executable sample

           //bin/aarch64-linux-gnu-ld: /home/hidenori/workspace/flutter/sample/elinux/flutter/ephemeral/libflutter_engine.so: error adding symbols: file in wrong format
           clang: error: linker command failed with exit code 1 (use -v to see invocation)
           gmake[2]: *** [runner/CMakeFiles/sample.dir/build.make:132: runner/sample] エラー 1
           gmake[1]: *** [CMakeFiles/Makefile2:198: runner/CMakeFiles/sample.dir/all] エラー 2
           gmake: *** [Makefile:136: all] エラー 2
[   +1 ms] 
           #0      throwToolExit (package:flutter_tools/src/base/common.dart:10:3)
           #1      NativeBundle.build (package:flutter_elinux/elinux_build_target.dart:398:7)
           <asynchronous suspension>
           #2      ELinuxBuilder.buildBundle (package:flutter_elinux/elinux_builder.dart:139:7)
           <asynchronous suspension>
           #3      BuildPackageCommand.runCommand (package:flutter_elinux/commands/build.dart:135:5)
           <asynchronous suspension>
           #4      FlutterCommand.run.<anonymous closure> (package:flutter_tools/src/runner/flutter_command.dart:1183:27)
           <asynchronous suspension>
           #5      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
           <asynchronous suspension>
           #6      CommandRunner.runCommand (package:args/command_runner.dart:209:13)
           <asynchronous suspension>
           #7      FlutterCommandRunner.runCommand.<anonymous closure> (package:flutter_tools/src/runner/flutter_command_runner.dart:281:9)
           <asynchronous suspension>
           #8      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
           <asynchronous suspension>
           #9      FlutterCommandRunner.runCommand (package:flutter_tools/src/runner/flutter_command_runner.dart:229:5)
           <asynchronous suspension>
           #10     run.<anonymous closure>.<anonymous closure> (package:flutter_tools/runner.dart:62:9)
           <asynchronous suspension>
           #11     AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
           <asynchronous suspension>
           #12     main (package:flutter_elinux/executable.dart:83:3)
           <asynchronous suspension>


[   +2 ms] ensureAnalyticsSent: 1ms
[        ] Running shutdown hooks
[        ] Shutdown hooks complete
[        ] exiting with code 1

```

Signed-off-by: Hidenori Matsubayashi <hidenori.matsubayashi@gmail.com>