### PR TITLE
broken cross compile work around added

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@
 Sony Group Corporation
 Michael Lamers (info@devmil.de)
 Andrea Daoud (andreadaoud6@gmail.com)
+Taha Firoz (mtahafiroz@gmail.com)

--- a/templates/app/CMakeLists.txt.tmpl
+++ b/templates/app/CMakeLists.txt.tmpl
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
-
+# https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#method-3-avoid-use-set
+# Unset `CMAKE_SYSROOT` before `project` because cmake 
+# tries to use `make` binary of SYSROOT which 
+# cannot be executed on host architecture 
 set(FLUTTER_SYS_ROOT ${CMAKE_SYSROOT})
 set(CMAKE_SYSROOT "")
 

--- a/templates/app/CMakeLists.txt.tmpl
+++ b/templates/app/CMakeLists.txt.tmpl
@@ -1,4 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
+
+set(FLUTTER_SYS_ROOT ${CMAKE_SYSROOT})
+set(CMAKE_SYSROOT "")
+
 project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "{{projectName}}")
@@ -10,6 +14,8 @@ set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
 # Basically we use this include when we got the following error:
 #  fatal error: 'bits/c++config.h' file not found
 include_directories(SYSTEM ${FLUTTER_SYSTEM_INCLUDE_DIRECTORIES})
+set(CMAKE_SYSROOT ${FLUTTER_SYS_ROOT})
+set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)

--- a/templates/app/CMakeLists.txt.tmpl
+++ b/templates/app/CMakeLists.txt.tmpl
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
-# https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#method-3-avoid-use-set
-# Unset `CMAKE_SYSROOT` before `project` because cmake 
-# tries to use `make` binary of SYSROOT which 
-# cannot be executed on host architecture 
-set(FLUTTER_SYS_ROOT ${CMAKE_SYSROOT})
-set(CMAKE_SYSROOT "")
-
+# stop cmake from taking make from CMAKE_SYSROOT
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "{{projectName}}")
@@ -17,9 +12,6 @@ set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
 # Basically we use this include when we got the following error:
 #  fatal error: 'bits/c++config.h' file not found
 include_directories(SYSTEM ${FLUTTER_SYSTEM_INCLUDE_DIRECTORIES})
-set(CMAKE_SYSROOT ${FLUTTER_SYS_ROOT})
-set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
-set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
Cross compile from x86 to arm is broken atleast for me, every since `CMAKE_SYSROOT` was passed directly the `try_compile` uses an arm compiler instead of a cross compiler which makes it fail everytime.

I have tried creating new projects and this is a reproducible error, compile any new flutter-elinux project with:
```
flutter-elinux build elinux -v --target-backend-type=gbm --target-compiler-triple=aarch64-linux-gnu  --target-arch=arm64  --target-sysroot=/home/me/rsc/arm64-sysroot --system-include-directories=/usr/aarch64-linux-gnu/include/c++/9/aarch64-linux-gnu
```

You will get this error:
```
Run Build Command(s):/home/me/rsc/arm64-sysroot/usr/bin/make cmTC_b676e/fast && /lib/ld-linux-aarch64.so.1: No such file or directory
```
This is because when `CMAKE_SYSROOT` is set before the `project` statement cmakes `try_compile` uses make from the arm64 sysroot which won't run on x86. My work around is simple just so I don't have to revert everything done in #105 set a temporary variable as `CMAKE_SYSROOT`, unset `CMAKE_SYSROOT`, let `try_compile` succeed then set `CMAKE_SYSROOT` to temp variable and set `CMAKE_FIND_ROOT_PATH`. 


This is only a work around but it finally works, also you need to update the  documentation that specifying ` --target-compiler-triple=aarch64-linux-gnu` for regular x86-arm is required now, the previous versions would add this flag automatically but this current version no longer adds it automatically and thus builds fail.