### PR TITLE
Add local elinux-artifacts use support

### DIFF
--- a/lib/executable.dart
+++ b/lib/executable.dart
@@ -137,6 +137,7 @@ Future<void> main(List<String> args) async {
             platform: globals.platform,
             osUtils: globals.os,
             projectFactory: globals.projectFactory,
+            processManager: globals.processManager,
           ),
       TemplateRenderer: () => const MustacheTemplateRenderer(),
       ApplicationPackageFactory: () => ELinuxApplicationPackageFactory(),


### PR DESCRIPTION
This change add ELINUX_ENGINE_BASE_LOCAL_DIRECTORY environment to use local artifacts of elinux without downloading them from GitHub.

#191