### PR TITLE
Add FLUTTER_ELINUX_CUSTOM_RUN_ARGS env to pass custom run options

### DIFF
--- a/lib/elinux_device.dart
+++ b/lib/elinux_device.dart
@@ -15,9 +15,9 @@ import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/custom_devices/custom_device.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/device_port_forwarder.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/protocol_discovery.dart';
-
 import 'package:process/process.dart';
 
 import 'elinux_builder.dart';
@@ -200,11 +200,20 @@ class ELinuxDevice extends Device {
     //  return LaunchResult.failed();
     //}
 
+    final String? elinuxCustomArgsEnv =
+        globals.platform.environment['FLUTTER_ELINUX_CUSTOM_RUN_ARGS'];
+    List<String> elinuxRunArgs = <String>[];
+    if (elinuxCustomArgsEnv != null) {
+      elinuxRunArgs.addAll(elinuxCustomArgsEnv.split(' '));
+    } else if (_desktop && _backendType == 'wayland') {
+      elinuxRunArgs.add('-d');
+    }
+
     final Process process = await _processManager.start(
       <String>[
         executable,
         executableOptions,
-        if (_desktop && _backendType == 'wayland') '-d',
+        ...elinuxRunArgs,
         ...debuggingOptions.dartEntrypointArgs,
       ],
       environment: _computeEnvironment(debuggingOptions, traceStartup, route),


### PR DESCRIPTION
This change adds `FLUTTER_ELINUX_CUSTOM_RUN_ARGS` to pass custom run options for elinux embedder.

e.g.
```
$ FLUTTER_ELINUX_CUSTOM_RUN_ARGS="-w 640 -h 480" flutter-elinux run -d elinux-wayland
```

Fixed https://github.com/sony/flutter-elinux/issues/200 and https://github.com/sony/flutter-elinux/issues/74.