### PR TITLE
upgrade: fix error messages when using upgrade command

### DIFF
--- a/lib/commands/upgrade.dart
+++ b/lib/commands/upgrade.dart
@@ -96,7 +96,9 @@ class ELinuxUpgradeCommandRunner {
 
     if (currentVersion.hash == upstreamVersion.hash) {
       globals.printStatus('flutter-elinux is already up to date');
-      globals.printStatus(upstreamVersion.gitTag!);
+      if (upstreamVersion.gitTag != null) {
+        globals.printStatus(upstreamVersion.gitTag!);
+      }
       return;
     }
 


### PR DESCRIPTION
This change fixes the following error messages when using upgrade command.

```
$ flutter-elinux upgrade
flutter-elinux is already up to date

Null check operator used on a null value
#0      ELinuxUpgradeCommandRunner.runCommandFirstHalf (package:flutter_elinux/commands/upgrade.dart:99:49)
<asynchronous suspension>
#1      ELinuxUpgradeCommandRunner.runCommand (package:flutter_elinux/commands/upgrade.dart:72:7)
<asynchronous suspension>
#2      FlutterCommand.run.<anonymous closure> (package:flutter_tools/src/runner/flutter_command.dart:1297:27)
<asynchronous suspension>
#3      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
<asynchronous suspension>
#4      CommandRunner.runCommand (package:args/command_runner.dart:212:13)
<asynchronous suspension>
#5      FlutterCommandRunner.runCommand.<anonymous closure> (package:flutter_tools/src/runner/flutter_command_runner.dart:339:9)
<asynchronous suspension>
#6      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
<asynchronous suspension>
#7      FlutterCommandRunner.runCommand (package:flutter_tools/src/runner/flutter_command_runner.dart:285:5)
<asynchronous suspension>
#8      run.<anonymous closure>.<anonymous closure> (package:flutter_tools/runner.dart:115:9)
<asynchronous suspension>
#9      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
<asynchronous suspension>
#10     main (package:flutter_elinux/executable.dart:80:3)
<asynchronous suspension>
```