### PR TITLE
gen_snapshot: fix Platform.operatingSystem issue

### DIFF
--- a/lib/commands/build.dart
+++ b/lib/commands/build.dart
@@ -88,12 +88,11 @@ class BuildPackageCommand extends BuildSubCommand
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async =>
       <DevelopmentArtifact>{
-        // Use gensnapshot for Arm64 Linux when the host is arm64 because
-        // the artifacts for arm64 host don't support self-building now.
+        // Use gen_snapshot of the arm64 linux-desktop when self-building
+        // on arm64 hosts. This is because elinux's artifacts for arm64
+        // doesn't support self-build as of now.
         if (_getCurrentHostPlatformArchName() == 'arm64')
           DevelopmentArtifact.linux,
-        if (_getCurrentHostPlatformArchName() == 'x64')
-          DevelopmentArtifact.androidGenSnapshot,
         ELinuxDevelopmentArtifact.elinux,
       };
 

--- a/lib/commands/run.dart
+++ b/lib/commands/run.dart
@@ -18,12 +18,11 @@ class ELinuxRunCommand extends RunCommand
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async =>
       <DevelopmentArtifact>{
-        // Use gensnapshot for Arm64 Linux when the host is arm64 because
-        // the artifacts for arm64 host don't support self-building now.
+        // Use gen_snapshot of the arm64 linux-desktop when self-building
+        // on arm64 hosts. This is because elinux's artifacts for arm64
+        // doesn't support self-build as of now.
         if (_getCurrentHostPlatformArchName() == 'arm64')
           DevelopmentArtifact.linux,
-        if (_getCurrentHostPlatformArchName() == 'x64')
-          DevelopmentArtifact.androidGenSnapshot,
         ELinuxDevelopmentArtifact.elinux,
       };
 

--- a/lib/elinux_artifacts.dart
+++ b/lib/elinux_artifacts.dart
@@ -34,16 +34,19 @@ class ELinuxArtifacts extends CachedArtifacts {
     BuildMode? mode,
     EnvironmentType? environmentType,
   }) {
+    final HostPlatform hostPlatform = getCurrentHostPlatform();
+
+    // Use elinux-*-*/linux-x64/gen_snapshot only when the host pc is x64 arch.
+    // The other causes use linux-desktop's one.
     if (artifact == Artifact.genSnapshot &&
+        hostPlatform == HostPlatform.linux_x64 &&
         platform != null &&
-        getNameForTargetPlatform(platform).startsWith('android')) {
+        getNameForTargetPlatform(platform).startsWith('linux')) {
       assert(mode != null, 'Need to specify a build mode.');
       assert(mode != BuildMode.debug,
           'Artifact $artifact only available in non-debug mode.');
+
       final String arch = _getArchForTargetPlatform(platform);
-      final HostPlatform hostPlatform = getCurrentHostPlatform();
-      assert(hostPlatform != HostPlatform.linux_arm64,
-          'Artifact $artifact not available on Linux arm64.');
       return _getEngineArtifactsDirectory(arch, mode!)
           .childDirectory(getNameForHostPlatform(hostPlatform))
           .childFile('gen_snapshot')
@@ -53,10 +56,10 @@ class ELinuxArtifacts extends CachedArtifacts {
   }
 
   String _getArchForTargetPlatform(TargetPlatform platform) {
-    if (platform == TargetPlatform.android_arm64) {
-      return 'arm64';
-    } else {
+    if (platform == TargetPlatform.linux_x64) {
       return 'x64';
+    } else {
+      return 'arm64';
     }
   }
 }

--- a/lib/elinux_builder.dart
+++ b/lib/elinux_builder.dart
@@ -12,7 +12,6 @@ import 'package:flutter_tools/src/android/gradle.dart';
 import 'package:flutter_tools/src/base/analyze_size.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -179,22 +178,11 @@ class ELinuxBuilder {
 
 /// See: [getTargetPlatformForName] in `build_info.dart`
 TargetPlatform _getTargetPlatformForArch(String arch) {
-  final String hostArch = _getCurrentHostPlatformArchName();
   switch (arch) {
     case 'arm64':
-      // Use gensnapshot for Arm64 Linux when the host is arm64 because
-      // the artifacts for arm64 host don't support self-building now.
-      if (hostArch == 'arm64') {
-        return TargetPlatform.linux_arm64;
-      }
-      return TargetPlatform.android_arm64;
+      return TargetPlatform.linux_arm64;
     default:
-      // Use gensnapshot for Arm64 Linux when the host is arm64 because
-      // the artifacts for arm64 host don't support self-building now.
-      if (hostArch == 'arm64') {
-        return TargetPlatform.linux_x64;
-      }
-      return TargetPlatform.android_x64;
+      return TargetPlatform.linux_x64;
   }
 }
 
@@ -210,9 +198,4 @@ String _getTargetPlatformPlatformName(TargetPlatform targetPlatform) {
     default:
       return 'android-x64';
   }
-}
-
-String _getCurrentHostPlatformArchName() {
-  final HostPlatform hostPlatform = getCurrentHostPlatform();
-  return hostPlatform.platformName;
 }


### PR DESCRIPTION
This change fixes an issue that `Platform.operatingSystem` returns Android on x64 hosts and when cross-building for arm64 targets on x64 hosts. To fix the issue, use the gen_snapshot of linux and elinux instead of Android's one.

Fixed https://github.com/sony/flutter-elinux/issues/212