### PR TITLE
fix: Unable to Build Projects with FFI Plugins in flutter-elinux

### DIFF
--- a/lib/elinux_plugins.dart
+++ b/lib/elinux_plugins.dart
@@ -565,7 +565,9 @@ void _writePluginCmakefileTemplate(
     ..removeWhere(methodChannelPlugins.contains);
 
   final List<Map<String, dynamic>> methodChannelPluginsMap =
-      methodChannelPlugins.map((ELinuxPlugin plugin) => plugin.toMap()).toList();
+      methodChannelPlugins
+          .map((ELinuxPlugin plugin) => plugin.toMap())
+          .toList();
   final List<Map<String, dynamic>> ffiPluginsMap =
       ffiPlugins.map((ELinuxPlugin plugin) => plugin.toMap()).toList();
 

--- a/lib/elinux_plugins.dart
+++ b/lib/elinux_plugins.dart
@@ -99,6 +99,21 @@ class ELinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
   }
 
   String get path => directory.parent.path;
+
+  /// Method to return a detailed debug string for the plugin.
+  @override
+  String toString() {
+    return '''
+ELinuxPlugin:
+  name: $name
+  directory: ${directory.path}
+  pluginClass: $pluginClass
+  dartPluginClass: $dartPluginClass
+  ffiPlugin: $ffiPlugin
+  defaultPackage: $defaultPackage
+  dependencies: ${dependencies?.join(', ')}
+''';
+  }
 }
 
 /// Source: [_internalCapitalLetterRegex] in `platform_plugins.dart` (exact copy)
@@ -426,12 +441,20 @@ Future<List<ELinuxPlugin>> findELinuxPlugins(
     final ELinuxPlugin? plugin = _pluginFromPackage(package.name, packageRoot);
     if (plugin == null) {
       continue;
-    } else if (nativeOnly &&
-        (plugin.pluginClass == null || plugin.pluginClass == 'none')) {
-      continue;
-    } else if (dartOnly && plugin.dartPluginClass == null) {
+    }
+
+    final bool isFfi = plugin.ffiPlugin ?? false;
+
+    if (nativeOnly &&
+        ((plugin.pluginClass == null || plugin.pluginClass == 'none') &&
+            !isFfi)) {
       continue;
     }
+
+    if (dartOnly && (plugin.dartPluginClass == null || isFfi)) {
+      continue;
+    }
+
     plugins.add(plugin);
   }
   return plugins;
@@ -513,18 +536,45 @@ void registerPlugins() {
   );
 }
 
+/// Filters out any plugins that don't use method channels, and thus shouldn't be added to the native generated registrants.
+List<ELinuxPlugin> _filterMethodChannelPlugins(List<ELinuxPlugin> plugins) {
+  return plugins.where((ELinuxPlugin plugin) {
+    return (plugin as NativeOrDartPlugin).hasMethodChannel();
+  }).toList();
+}
+
+/// Filters out Dart-only and method channel plugins.
+///
+/// FFI plugins do not need native code registration, but their binaries need to be bundled.
+List<ELinuxPlugin> _filterFfiPlugins(List<ELinuxPlugin> plugins) {
+  return plugins.where((ELinuxPlugin plugin) {
+    final NativeOrDartPlugin plugin_ = plugin as NativeOrDartPlugin;
+    return plugin_.hasFfi();
+  }).toList();
+}
+
 /// See: [_writeWindowsPluginFiles] in `plugins.dart`
 void _writePluginCmakefileTemplate(
   ELinuxProject eLinuxProject,
   Directory registryDirectory,
   List<ELinuxPlugin> plugins,
 ) {
-  final List<Map<String, dynamic>> pluginConfigs =
-      plugins.map((ELinuxPlugin plugin) => plugin.toMap()).toList();
+  final List<ELinuxPlugin> methodChannelPlugins =
+      _filterMethodChannelPlugins(plugins);
+  final List<ELinuxPlugin> ffiPlugins = _filterFfiPlugins(plugins)
+    ..removeWhere(methodChannelPlugins.contains);
+
+  final List<Map<String, dynamic>> methodChannelPluginsMap =
+      methodChannelPlugins.map((ELinuxPlugin plugin) => plugin.toMap()).toList();
+  final List<Map<String, dynamic>> ffiPluginsMap =
+      ffiPlugins.map((ELinuxPlugin plugin) => plugin.toMap()).toList();
+
   final Map<String, dynamic> context = <String, dynamic>{
-    'plugins': pluginConfigs,
+    'methodChannelPlugins': methodChannelPluginsMap,
+    'ffiPlugins': ffiPluginsMap,
     'pluginsDir': _cmakeRelativePluginSymlinkDirectoryPath(eLinuxProject),
   };
+
   _renderTemplateToFile(
     '''
 //
@@ -547,22 +597,23 @@ void RegisterPlugins(flutter::PluginRegistry* registry);
   _renderTemplateToFile(
     '''
 //
-// Generated file. Do not edit.
+//  Generated file. Do not edit.
 //
 
 // clang-format off
 
 #include "generated_plugin_registrant.h"
 
-{{#plugins}}
+{{#methodChannelPlugins}}
 #include <{{name}}/{{filename}}.h>
-{{/plugins}}
+{{/methodChannelPlugins}}
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-{{#plugins}}
-  {{class}}RegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("{{class}}"));
-{{/plugins}}
+{{#methodChannelPlugins}}
+  g_autoptr(FlPluginRegistrar) {{name}}_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "{{class}}");
+  {{filename}}_register_with_registrar({{name}}_registrar);
+{{/methodChannelPlugins}}
 }
 ''',
     context,
@@ -575,9 +626,15 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-{{#plugins}}
+{{#methodChannelPlugins}}
   {{name}}
-{{/plugins}}
+{{/methodChannelPlugins}}
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+{{#ffiPlugins}}
+  {{name}}
+{{/ffiPlugins}}
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)
@@ -588,6 +645,11 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory({{pluginsDir}}/${ffi_plugin}/elinux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)
 ''',
     context,
     registryDirectory.childFile('generated_plugins.cmake').path,

--- a/lib/elinux_plugins.dart
+++ b/lib/elinux_plugins.dart
@@ -612,9 +612,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry);
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
 {{#methodChannelPlugins}}
-  g_autoptr(FlPluginRegistrar) {{name}}_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "{{class}}");
-  {{filename}}_register_with_registrar({{name}}_registrar);
+  {{class}}RegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("{{class}}"));
 {{/methodChannelPlugins}}
 }
 ''',


### PR DESCRIPTION
#### Background
Flutter has modified the way it retrieves plugins. The `messageChannel` plugins and `ffi` plugins are now retrieved and imported separately. Currently, the internal implementation of `flutter-elinux` has not been updated to reflect this change, resulting in build failures for plugins that depend on FFI, such as `cargokit` and `rinf`.

#### Solution
This PR references the official Flutter implementation to provide a fix for this issue. The changes ensure that plugins relying on FFI are correctly compiled and processed.

#### Important Note
I do not have any experience with C/C++, so I am unable to determine if certain modifications are appropriate. Specifically, I am referring to the changes in the following section:

[Link to the specific changes](https://github.com/Losses/flutter-elinux/commit/732c6c9beb7c3b605a58f0b5f86b8046ec11f222#diff-bec27cab5e38b28d7405704768b519225416c013cdb454092bfb1015dd4c439cR613-R615)

However, the fix for FFI has been locally verified and is confirmed to be correct and effective.

#### Changes
- Updated the plugin retrieval mechanism to align with the latest Flutter implementation.
- Ensured that plugins relying on FFI are correctly compiled and processed.

Please review the changes and provide feedback, especially on the C/C++ modifications.

Thank you for your attention to this matter.

FIX: #270 
