### PR TITLE
fix: Fixes for Cross-Compilation Issues

### DIFF
--- a/lib/elinux_build_target.dart
+++ b/lib/elinux_build_target.dart
@@ -384,12 +384,6 @@ class NativeBundle {
         eLinuxDir.path,
       ],
       workingDirectory: outputDir.path,
-      environment: (targetToolchain == null)
-          ? <String, String>{'CC': 'clang', 'CXX': 'clang++'}
-          : <String, String>{
-              'CC': '$targetToolchain/bin/clang',
-              'CXX': '$targetToolchain/bin/clang++'
-            },
     );
     if (result.exitCode != 0) {
       throwToolExit('Failed to cmake:\n$result');

--- a/lib/elinux_build_target.dart
+++ b/lib/elinux_build_target.dart
@@ -384,6 +384,7 @@ class NativeBundle {
         eLinuxDir.path,
       ],
       workingDirectory: outputDir.path,
+      environment: _buildCMakeEnvironment(targetToolchain),
     );
     if (result.exitCode != 0) {
       throwToolExit('Failed to cmake:\n$result');
@@ -402,7 +403,6 @@ class NativeBundle {
         numProc,
       ],
       workingDirectory: outputDir.path,
-      environment: _buildCMakeEnvironment(targetToolchain),
     );
     if (result.exitCode != 0) {
       throwToolExit('Failed to cmake build:\n$result');

--- a/lib/elinux_build_target.dart
+++ b/lib/elinux_build_target.dart
@@ -402,6 +402,7 @@ class NativeBundle {
         numProc,
       ],
       workingDirectory: outputDir.path,
+      environment: _buildCMakeEnvironment(targetToolchain),
     );
     if (result.exitCode != 0) {
       throwToolExit('Failed to cmake build:\n$result');
@@ -424,6 +425,18 @@ class NativeBundle {
       );
     }
   }
+}
+
+Map<String, String> _buildCMakeEnvironment(String? targetToolchain) {
+  final String? ccEnv = Platform.environment['CC'];
+  final String? cxxEnv = Platform.environment['CXX'];
+
+  final String cc = ccEnv ??
+      (targetToolchain != null ? '$targetToolchain/bin/clang' : 'clang');
+  final String cxx = cxxEnv ??
+      (targetToolchain != null ? '$targetToolchain/bin/clang++' : 'clang++');
+
+  return <String, String>{'CC': cc, 'CXX': cxx};
 }
 
 String _getCurrentHostPlatformArchName() {

--- a/lib/elinux_plugins.dart
+++ b/lib/elinux_plugins.dart
@@ -565,7 +565,9 @@ void _writePluginCmakefileTemplate(
     ..removeWhere(methodChannelPlugins.contains);
 
   final List<Map<String, dynamic>> methodChannelPluginsMap =
-      methodChannelPlugins.map((ELinuxPlugin plugin) => plugin.toMap()).toList();
+      methodChannelPlugins
+          .map((ELinuxPlugin plugin) => plugin.toMap())
+          .toList();
   final List<Map<String, dynamic>> ffiPluginsMap =
       ffiPlugins.map((ELinuxPlugin plugin) => plugin.toMap()).toList();
 

--- a/lib/elinux_plugins.dart
+++ b/lib/elinux_plugins.dart
@@ -99,6 +99,21 @@ class ELinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
   }
 
   String get path => directory.parent.path;
+
+  /// Method to return a detailed debug string for the plugin.
+  @override
+  String toString() {
+    return '''
+ELinuxPlugin:
+  name: $name
+  directory: ${directory.path}
+  pluginClass: $pluginClass
+  dartPluginClass: $dartPluginClass
+  ffiPlugin: $ffiPlugin
+  defaultPackage: $defaultPackage
+  dependencies: ${dependencies?.join(', ')}
+''';
+  }
 }
 
 /// Source: [_internalCapitalLetterRegex] in `platform_plugins.dart` (exact copy)
@@ -426,12 +441,20 @@ Future<List<ELinuxPlugin>> findELinuxPlugins(
     final ELinuxPlugin? plugin = _pluginFromPackage(package.name, packageRoot);
     if (plugin == null) {
       continue;
-    } else if (nativeOnly &&
-        (plugin.pluginClass == null || plugin.pluginClass == 'none')) {
-      continue;
-    } else if (dartOnly && plugin.dartPluginClass == null) {
+    }
+
+    final bool isFfi = plugin.ffiPlugin ?? false;
+
+    if (nativeOnly &&
+        ((plugin.pluginClass == null || plugin.pluginClass == 'none') &&
+            !isFfi)) {
       continue;
     }
+
+    if (dartOnly && (plugin.dartPluginClass == null || isFfi)) {
+      continue;
+    }
+
     plugins.add(plugin);
   }
   return plugins;
@@ -513,18 +536,45 @@ void registerPlugins() {
   );
 }
 
+/// Filters out any plugins that don't use method channels, and thus shouldn't be added to the native generated registrants.
+List<ELinuxPlugin> _filterMethodChannelPlugins(List<ELinuxPlugin> plugins) {
+  return plugins.where((ELinuxPlugin plugin) {
+    return (plugin as NativeOrDartPlugin).hasMethodChannel();
+  }).toList();
+}
+
+/// Filters out Dart-only and method channel plugins.
+///
+/// FFI plugins do not need native code registration, but their binaries need to be bundled.
+List<ELinuxPlugin> _filterFfiPlugins(List<ELinuxPlugin> plugins) {
+  return plugins.where((ELinuxPlugin plugin) {
+    final NativeOrDartPlugin plugin_ = plugin as NativeOrDartPlugin;
+    return plugin_.hasFfi();
+  }).toList();
+}
+
 /// See: [_writeWindowsPluginFiles] in `plugins.dart`
 void _writePluginCmakefileTemplate(
   ELinuxProject eLinuxProject,
   Directory registryDirectory,
   List<ELinuxPlugin> plugins,
 ) {
-  final List<Map<String, dynamic>> pluginConfigs =
-      plugins.map((ELinuxPlugin plugin) => plugin.toMap()).toList();
+  final List<ELinuxPlugin> methodChannelPlugins =
+      _filterMethodChannelPlugins(plugins);
+  final List<ELinuxPlugin> ffiPlugins = _filterFfiPlugins(plugins)
+    ..removeWhere(methodChannelPlugins.contains);
+
+  final List<Map<String, dynamic>> methodChannelPluginsMap =
+      methodChannelPlugins.map((ELinuxPlugin plugin) => plugin.toMap()).toList();
+  final List<Map<String, dynamic>> ffiPluginsMap =
+      ffiPlugins.map((ELinuxPlugin plugin) => plugin.toMap()).toList();
+
   final Map<String, dynamic> context = <String, dynamic>{
-    'plugins': pluginConfigs,
+    'methodChannelPlugins': methodChannelPluginsMap,
+    'ffiPlugins': ffiPluginsMap,
     'pluginsDir': _cmakeRelativePluginSymlinkDirectoryPath(eLinuxProject),
   };
+
   _renderTemplateToFile(
     '''
 //
@@ -547,22 +597,23 @@ void RegisterPlugins(flutter::PluginRegistry* registry);
   _renderTemplateToFile(
     '''
 //
-// Generated file. Do not edit.
+//  Generated file. Do not edit.
 //
 
 // clang-format off
 
 #include "generated_plugin_registrant.h"
 
-{{#plugins}}
+{{#methodChannelPlugins}}
 #include <{{name}}/{{filename}}.h>
-{{/plugins}}
+{{/methodChannelPlugins}}
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-{{#plugins}}
-  {{class}}RegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("{{class}}"));
-{{/plugins}}
+{{#methodChannelPlugins}}
+  g_autoptr(FlPluginRegistrar) {{name}}_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "{{class}}");
+  {{filename}}_register_with_registrar({{name}}_registrar);
+{{/methodChannelPlugins}}
 }
 ''',
     context,
@@ -575,9 +626,15 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-{{#plugins}}
+{{#methodChannelPlugins}}
   {{name}}
-{{/plugins}}
+{{/methodChannelPlugins}}
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+{{#ffiPlugins}}
+  {{name}}
+{{/ffiPlugins}}
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)
@@ -588,6 +645,11 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory({{pluginsDir}}/${ffi_plugin}/elinux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)
 ''',
     context,
     registryDirectory.childFile('generated_plugins.cmake').path,

--- a/lib/elinux_plugins.dart
+++ b/lib/elinux_plugins.dart
@@ -612,9 +612,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry);
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
 {{#methodChannelPlugins}}
-  g_autoptr(FlPluginRegistrar) {{name}}_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "{{class}}");
-  {{filename}}_register_with_registrar({{name}}_registrar);
+  {{class}}RegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("{{class}}"));
 {{/methodChannelPlugins}}
 }
 ''',

--- a/templates/app/flutter/CMakeLists.txt
+++ b/templates/app/flutter/CMakeLists.txt
@@ -54,6 +54,35 @@ target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
 target_link_libraries(flutter INTERFACE "${FLUTTER_EMBEDDER_LIBRARY}")
 add_dependencies(flutter flutter_assemble)
 
+# === Find Dependencies ===
+find_package(Fontconfig REQUIRED)
+find_package(X11 REQUIRED xkbcommon)
+find_package(OpenGL REQUIRED COMPONENTS EGL)
+
+# Use pkg-config to find Wayland libraries
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(WAYLAND_EGL REQUIRED wayland-egl)
+pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
+pkg_check_modules(WAYLAND_CURSOR REQUIRED wayland-cursor)
+
+# Link the dependencies to the flutter target
+target_link_libraries(flutter INTERFACE
+  Fontconfig::Fontconfig
+  X11::xkbcommon
+  OpenGL::EGL
+  ${WAYLAND_EGL_LIBRARIES}
+  ${WAYLAND_CLIENT_LIBRARIES}
+  ${WAYLAND_CURSOR_LIBRARIES}
+)
+
+# Include directories for the dependencies
+target_include_directories(flutter INTERFACE
+  ${X11_INCLUDE_DIR}
+  ${WAYLAND_EGL_INCLUDE_DIRS}
+  ${WAYLAND_CLIENT_INCLUDE_DIRS}
+  ${WAYLAND_CURSOR_INCLUDE_DIRS}
+)
+
 # === Wrapper ===
 list(APPEND CPP_WRAPPER_SOURCES_CORE
   "core_implementations.cc"


### PR DESCRIPTION
This pull request includes two key modifications to address potential issues in the cross-compilation process:

## 1. Configuration Updates in `CMakeLists.txt`

Introducing necessary configurations in `CMakeLists.txt` to ensure the correct discovery and linking of package directories during cross-compilation. The changes include:

- **Finding and Linking Required Packages**: 
  - Fontconfig
  - X11 with xkbcommon
  - OpenGL with EGL
- **Utilizing pkg-config** to locate Wayland libraries:
  - wayland-egl
  - wayland-client
  - wayland-cursor
- **Linking Dependencies**: These dependencies are linked to the flutter target.
- **Including Necessary Directories**: The required directories for these dependencies are included.

### Problem Addressed:
Previously, the build system struggled to correctly locate package directories during cross-compilation, leading to build failures. These changes ensure that the necessary packages and libraries are correctly found and linked, thereby facilitating a successful build process.

## 2. Fix for Diverse Compiler Invocation Commands

Resolving issues related to cross-platform compilation on certain operating systems, such as NixOS, by supporting diverse compiler invocation commands.

### Details:
- **Issue**: The current implementation assumed specific commands for invoking `clang` and `clang++`. However, different operating systems might use different commands. For instance, on NixOS, the commands are `aarch64-unknown-linux-gnu-clang` and `aarch64-unknown-linux-gnu-clang++`.
- **Solution**: The commit respects the original environment variable settings, allowing users to specify the binary names provided by their distribution. This flexibility improves support for various operating systems and compilation environments.

### Problem Addressed:
Certain operating systems were unable to complete cross-platform compilation due to hardcoded compiler invocation commands. By allowing customizable compiler commands, this fix enhances the project's cross-platform compatibility.

Potentially related to #159, since an incorrect compiler could trigger the same error.